### PR TITLE
Use fabric3 for compatibility with Python 3

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -8,7 +8,7 @@ def test():
         abort("Aborted at user request.")
 
 def commit():
-    message = raw_input("Enter a git commit message: ")
+    message = input("Enter a git commit message: ")
     local("git add . && git commit -am '{}'".format(message))
 
 def push():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cffi==1.9.1
 coverage==3.7.1
 cryptography==1.7.1
 Fabric==1.13.1
+Fabric3==1.13.1.post1
 Flask==0.10.1
 Flask-Bcrypt==0.7.1
 Flask-SQLAlchemy==2.0
@@ -19,4 +20,5 @@ pycparser==2.17
 six==1.10.0
 SQLAlchemy==1.1.4
 Werkzeug==0.11.11
+wheel==0.24.0
 WTForms==2.1


### PR DESCRIPTION
All new Python code should be written with Python 3 in mind. With that in mind, raw_input() should be replaced with input().